### PR TITLE
Fix string params being sent in binary format

### DIFF
--- a/src/mrb_pq.c
+++ b/src/mrb_pq.c
@@ -130,7 +130,7 @@ mrb_pq_encode_value(mrb_state *mrb, mrb_value value, Oid *paramType, int *paramL
       value = mrb_str_to_str(mrb, value);
       *paramType = 0;
       *paramLength = RSTRING_LEN(value);
-      *paramFormat = 1;
+      *paramFormat = 0;
       return RSTRING_PTR(value);
     }
   }


### PR DESCRIPTION
The default case in `mrb_pq_encode_value` sends string parameters with `paramFormat = 1` (binary).
This causes PostgreSQL to misinterpret text data — for example, inserting JSON into a `jsonb` column
fails with "unsupported jsonb version number 91".

This PR sets `paramFormat = 0` (text) to match the other text-based cases (bool, NULL).