### PR TITLE
Add minimal manual COPY support

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,53 @@ end
 
 `n` is a `Pq::Notify` with `relname`, `be_pid`, and `extra` accessors.
 
+### COPY (manual, row-by-row)
+
+The gem deliberately ships no bulk COPY helpers — mruby caps strings at 1MB
+on some platforms, and file-based bulk loading is already served by `psql`.
+What it wraps is the minimal per-row API, so a `COPY` issued manually
+through `exec` can be driven (or aborted) instead of wedging the connection.
+No call ever handles more than one row at a time, so the string cap is
+never in play.
+
+Sending data (`COPY ... FROM STDIN`):
+```ruby
+res = conn.exec("COPY mytable FROM STDIN")
+raise "unexpected #{res.status}" unless res.copy_in?
+conn.put_copy_data("1\tfoo\n")
+conn.put_copy_data("2\tbar\n")
+conn.put_copy_end
+while (res = conn.get_result); end   # drain the final COMMAND_OK / error
+```
+
+Receiving data (`COPY ... TO STDOUT`):
+```ruby
+res = conn.exec("COPY mytable TO STDOUT")
+raise "unexpected #{res.status}" unless res.copy_out?
+while (row = conn.get_copy_data)
+  print row                          # one data row per call
+end
+while (res = conn.get_result); end
+```
+
+`get_copy_data` takes no arguments — whether it blocks follows the
+connection's own nonblocking state. It returns one row per call, `nil` once
+the COPY is finished (then drain `get_result`), or `:would_block` when the
+connection is in nonblocking mode and no complete row has arrived yet (wait
+readable, `consume_input`, retry).
+
+`put_copy_data` and `put_copy_end` return `true` when the data was queued
+and `false` when the send would block in nonblocking mode (wait writable,
+`flush`, retry).
+
+`put_copy_end("some message")` force-fails the COPY server-side. This is
+also the escape hatch when SQL fed through `exec` unexpectedly starts a
+COPY: abort it, drain `get_result`, and the connection stays usable — no
+`reset` needed.
+
+Don't use the block form of `exec` for COPY statements — it drives
+single-row mode and cannot service the copy protocol.
+
 ### Method reference
 
 | Method                                | Wraps                       |
@@ -276,6 +323,9 @@ end
 | `conn.get_result`                     | `PQgetResult`               |
 | `conn.set_single_row_mode`            | `PQsetSingleRowMode`        |
 | `conn.notifies`                       | `PQnotifies`                |
+| `conn.put_copy_data(data)`            | `PQputCopyData`             |
+| `conn.put_copy_end(message = nil)`    | `PQputCopyEnd`              |
+| `conn.get_copy_data`                  | `PQgetCopyData`             |
 
 `connect_poll` returns `:reading`, `:writing`, `:ok`, or `:failed`. (libpq
 also defines a deprecated `:active` state; the gem exposes it for

--- a/src/mrb_pq.c
+++ b/src/mrb_pq.c
@@ -768,6 +768,90 @@ mrb_PQnotifies_m(mrb_state *mrb, mrb_value self)
   return result;
 }
 
+static mrb_value
+mrb_PQputCopyData_m(mrb_state *mrb, mrb_value self)
+{
+  char *data;
+  mrb_int len;
+  mrb_get_args(mrb, "s", &data, &len);
+  mrb_assert_int_fit(mrb_int, len, int, INT_MAX);
+  PGconn *conn = (PGconn *) mrb_data_check_get_ptr(mrb, self, &mrb_PGconn_type);
+  if (!conn) {
+    mrb_raise(mrb, E_IO_ERROR, "closed stream");
+  }
+
+  errno = 0;
+  int r = PQputCopyData(conn, data, (int) len);
+  if (unlikely(r == -1)) {
+    mrb_pq_handle_connection_error(mrb, self, conn);
+  }
+  /* true = queued, false = would block (nonblocking mode; retry after flush) */
+  return mrb_bool_value(r == 1);
+}
+
+static mrb_value
+mrb_PQputCopyEnd_m(mrb_state *mrb, mrb_value self)
+{
+  const char *errormsg = NULL;
+  mrb_get_args(mrb, "|z!", &errormsg);
+  PGconn *conn = (PGconn *) mrb_data_check_get_ptr(mrb, self, &mrb_PGconn_type);
+  if (!conn) {
+    mrb_raise(mrb, E_IO_ERROR, "closed stream");
+  }
+
+  errno = 0;
+  int r = PQputCopyEnd(conn, errormsg);
+  if (unlikely(r == -1)) {
+    mrb_pq_handle_connection_error(mrb, self, conn);
+  }
+  /* true = sent, false = would block (nonblocking mode; retry after flush) */
+  return mrb_bool_value(r == 1);
+}
+
+typedef struct {
+  char *buffer;
+  int len;
+} mrb_pq_copy_row_arg;
+
+static mrb_value
+mrb_pq_copy_row_build(mrb_state *mrb, void *arg_)
+{
+  mrb_pq_copy_row_arg *arg = (mrb_pq_copy_row_arg *) arg_;
+  return mrb_str_new(mrb, arg->buffer, arg->len);
+}
+
+static mrb_value
+mrb_PQgetCopyData_m(mrb_state *mrb, mrb_value self)
+{
+  PGconn *conn = (PGconn *) mrb_data_check_get_ptr(mrb, self, &mrb_PGconn_type);
+  if (!conn) {
+    mrb_raise(mrb, E_IO_ERROR, "closed stream");
+  }
+
+  char *buffer = NULL;
+  errno = 0;
+  int r = PQgetCopyData(conn, &buffer, PQisnonblocking(conn));
+  switch (r) {
+    case 0: /* nonblocking mode: no complete row available yet */
+      return mrb_symbol_value(MRB_SYM(would_block));
+    case -1: /* COPY finished; drain get_result for the final status */
+      return mrb_nil_value();
+    case -2:
+      mrb_pq_handle_connection_error(mrb, self, conn);
+      return mrb_nil_value(); /* not reached */
+    default: {
+      /* Anything raised before PQfreemem(buffer) would leak the libpq
+         buffer, so build the row string under mrb_protect_error. */
+      mrb_pq_copy_row_arg arg = { .buffer = buffer, .len = r };
+      mrb_bool err = FALSE;
+      mrb_value row = mrb_protect_error(mrb, mrb_pq_copy_row_build, &arg, &err);
+      PQfreemem(buffer);
+      if (err) mrb_exc_raise(mrb, row);
+      return row;
+    }
+  }
+}
+
 /* ===================================================================
  * end async-aware additions (query execution)
  * =================================================================== */
@@ -1093,6 +1177,9 @@ mrb_mruby_postgresql_gem_init(mrb_state *mrb)
   mrb_define_method_id(mrb, pq_class, MRB_SYM(get_result), mrb_PQgetResult_m, MRB_ARGS_NONE());
   mrb_define_method_id(mrb, pq_class, MRB_SYM(set_single_row_mode), mrb_PQsetSingleRowMode_m, MRB_ARGS_NONE());
   mrb_define_method_id(mrb, pq_class, MRB_SYM(notifies), mrb_PQnotifies_m, MRB_ARGS_NONE());
+  mrb_define_method_id(mrb, pq_class, MRB_SYM(put_copy_data), mrb_PQputCopyData_m, MRB_ARGS_REQ(1));
+  mrb_define_method_id(mrb, pq_class, MRB_SYM(put_copy_end), mrb_PQputCopyEnd_m, MRB_ARGS_OPT(1));
+  mrb_define_method_id(mrb, pq_class, MRB_SYM(get_copy_data), mrb_PQgetCopyData_m, MRB_ARGS_NONE());
   /* Pq::Notify is fleshed out in mrblib/pq.rb; defined here so that
      mrb_class_get_under_id always finds it. */
   pq_notify_class = mrb_define_class_under_id(mrb, pq_class, MRB_SYM(Notify), mrb->object_class);

--- a/test/pq.rb
+++ b/test/pq.rb
@@ -329,3 +329,53 @@ assert("Async: error_message returns a String") do
   assert_kind_of String, conn.error_message
   conn.close
 end
+
+# ===========================================================================
+# COPY (manual, row-by-row)
+# ===========================================================================
+
+assert("COPY: round-trip via put_copy_data / get_copy_data") do
+  conn = Pq.new("postgresql://localhost/postgres")
+  conn.exec("create temp table copy_test (id int4, word text)")
+
+  res = conn.exec("COPY copy_test FROM STDIN")
+  assert_true res.copy_in?
+  assert_true conn.put_copy_data("1\tfoo\n")
+  assert_true conn.put_copy_data("2\tbar\n")
+  assert_true conn.put_copy_end
+  final = conn.get_result
+  assert_true final.command_ok?
+  assert_nil conn.get_result
+
+  res = conn.exec("COPY copy_test TO STDOUT")
+  assert_true res.copy_out?
+  rows = []
+  while (row = conn.get_copy_data)
+    rows << row
+  end
+  assert_equal ["1\tfoo\n", "2\tbar\n"], rows
+  final = conn.get_result
+  assert_true final.command_ok?
+  assert_nil conn.get_result
+
+  # the connection stays usable after a completed COPY
+  assert_equal [[2]], conn.exec("select count(*)::int4 from copy_test").to_ary
+  conn.close
+end
+
+assert("COPY: put_copy_end with message aborts, connection recovers") do
+  conn = Pq.new("postgresql://localhost/postgres")
+  conn.exec("create temp table copy_abort_test (id int4)")
+
+  res = conn.exec("COPY copy_abort_test FROM STDIN")
+  assert_true res.copy_in?
+  assert_true conn.put_copy_data("1\n")
+  assert_true conn.put_copy_end("aborted by test")
+  final = conn.get_result
+  assert_true final.is_a?(Pq::Result::FatalError)
+  assert_nil conn.get_result
+
+  # the abort discarded the pending row and the connection stays usable
+  assert_equal [[0]], conn.exec("select count(*)::int4 from copy_abort_test").to_ary
+  conn.close
+end


### PR DESCRIPTION
Wraps libpq's per-row COPY data plane so a `COPY` issued manually through `exec` can be driven to completion (or aborted) instead of wedging the connection until `reset`.

## New methods

| Method | Wraps | Returns |
|---|---|---|
| `conn.put_copy_data(data)` | `PQputCopyData` | `true` queued, `false` would-block (nonblocking mode), raises on error |
| `conn.put_copy_end(message = nil)` | `PQputCopyEnd` | same; passing a message force-fails the COPY server-side |
| `conn.get_copy_data` | `PQgetCopyData` | one row per call; `nil` when the COPY is finished; `:would_block` in nonblocking mode |

## Design notes

- `get_copy_data` takes no arguments — the async flag is derived from the connection's own nonblocking state via `PQisnonblocking`, consistent with how the rest of the gem behaves.
- Data flows one row per call, so no string ever holds more than a single row — deliberately compatible with mruby's 1MB string cap on small platforms. Bulk COPY helpers remain out of scope; file-based bulk loading is already served by `psql`.
- The row buffer from `PQgetCopyData` is built into an mruby string under `mrb_protect_error` with a guaranteed `PQfreemem`, mirroring the existing `PQnotifies` wrapper.
- `put_copy_end("message")` doubles as the escape hatch when SQL fed through `exec` unexpectedly starts a COPY: abort it, drain `get_result`, and the connection stays usable — no `reset` needed.

## Docs & tests

- README gains a "COPY (manual, row-by-row)" section with the COPY IN / COPY OUT sequences and the recovery pattern, plus method-reference entries.
- `test/pq.rb` gains a live round-trip test (COPY IN two rows → COPY OUT → assert equality → connection still usable) and an abort test (`put_copy_end("msg")` → `Pq::Result::FatalError` → connection recovers).