### PR TITLE
Add libpq primitives for tooling built on top

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,12 @@ single-row mode and cannot service the copy protocol.
 | `conn.put_copy_data(data)`            | `PQputCopyData`             |
 | `conn.put_copy_end(message = nil)`    | `PQputCopyEnd`              |
 | `conn.get_copy_data`                  | `PQgetCopyData`             |
+| `conn.transaction_status`             | `PQtransactionStatus`       |
+| `conn.escape_identifier(str)`         | `PQescapeIdentifier`        |
+| `conn.escape_literal(str)`            | `PQescapeLiteral`           |
+| `res.cmd_status`                      | `PQcmdStatus`               |
+| `res.cmd_tuples`                      | `PQcmdTuples`               |
+| `res.error_message`                   | `PQresultErrorMessage`      |
 
 `connect_poll` returns `:reading`, `:writing`, `:ok`, or `:failed`. (libpq
 also defines a deprecated `:active` state; the gem exposes it for
@@ -335,3 +341,24 @@ completeness but it never appears on modern libpq.)
 lowercase: `:ok`, `:bad`, `:started`, `:made`, `:awaiting_response`,
 `:auth_ok`, `:setenv`, `:ssl_startup`, `:needed`. Newer libpq states fall
 through to the underlying integer.
+
+Building tools on top (migrations etc.)
+---------------------------------------
+Higher-level concerns like schema migrations are deliberately **not** part
+of this gem — they belong in a database-agnostic gem that drives multiple
+backends (PostgreSQL, SQLite, MySQL, ...) through per-backend adapters.
+This gem exposes the primitives such an adapter needs:
+
+- `conn.exec(sql, *params)` — parameterized execution; errors come back as
+  result objects with full diagnostics (`sqlstate`, `error_message`, ...)
+- transactions are plain SQL (`BEGIN` / `COMMIT` / `ROLLBACK`), and
+  `conn.transaction_status` reports where the connection stands:
+  `:idle`, `:active`, `:intrans` (in a transaction), `:inerror` (in an
+  aborted transaction), `:unknown`
+- `conn.escape_identifier(name)` / `conn.escape_literal(value)` — libpq's
+  own quoting for the places `$1` parameters cannot go (dynamic table
+  names, DDL)
+- `res.cmd_tuples` — rows affected by INSERT/UPDATE/DELETE (`nil` when the
+  command reports no count), `res.cmd_status` — the command tag
+- `res.error_message` — the full server error message of a result
+  (`Exception#message` cannot read it on these data-wrapped objects)

--- a/src/mrb_pq.c
+++ b/src/mrb_pq.c
@@ -856,6 +856,97 @@ mrb_PQgetCopyData_m(mrb_state *mrb, mrb_value self)
  * end async-aware additions (query execution)
  * =================================================================== */
 
+/* ===================================================================
+ * Primitives for tooling built on top (migration gems etc.)
+ * =================================================================== */
+
+static mrb_value
+mrb_PQtransactionStatus_m(mrb_state *mrb, mrb_value self)
+{
+  const PGconn *conn = (const PGconn *) mrb_data_check_get_ptr(mrb, self, &mrb_PGconn_type);
+  if (!conn) {
+    mrb_raise(mrb, E_IO_ERROR, "closed stream");
+  }
+
+  switch (PQtransactionStatus(conn)) {
+    case PQTRANS_IDLE:    return mrb_symbol_value(MRB_SYM(idle));
+    case PQTRANS_ACTIVE:  return mrb_symbol_value(MRB_SYM(active));
+    case PQTRANS_INTRANS: return mrb_symbol_value(MRB_SYM(intrans));
+    case PQTRANS_INERROR: return mrb_symbol_value(MRB_SYM(inerror));
+    default:              return mrb_symbol_value(MRB_SYM(unknown));
+  }
+}
+
+/* PQescapeIdentifier / PQescapeLiteral both return a freshly malloc'd,
+   NUL-terminated string (or NULL on error); build the mruby string under
+   mrb_protect_error so PQfreemem is guaranteed, like the COPY row path. */
+static mrb_value
+mrb_pq_escape(mrb_state *mrb, mrb_value self, char *(*escape)(PGconn *, const char *, size_t))
+{
+  const char *str;
+  mrb_int len;
+  mrb_get_args(mrb, "s", &str, &len);
+  PGconn *conn = (PGconn *) mrb_data_check_get_ptr(mrb, self, &mrb_PGconn_type);
+  if (!conn) {
+    mrb_raise(mrb, E_IO_ERROR, "closed stream");
+  }
+
+  errno = 0;
+  char *quoted = escape(conn, str, (size_t) len);
+  if (unlikely(!quoted)) {
+    mrb_pq_handle_connection_error(mrb, self, conn);
+  }
+
+  mrb_pq_copy_row_arg arg = { .buffer = quoted, .len = (int) strlen(quoted) };
+  mrb_bool err = FALSE;
+  mrb_value ret = mrb_protect_error(mrb, mrb_pq_copy_row_build, &arg, &err);
+  PQfreemem(quoted);
+  if (err) mrb_exc_raise(mrb, ret);
+  return ret;
+}
+
+static mrb_value
+mrb_PQescapeIdentifier_m(mrb_state *mrb, mrb_value self)
+{
+  return mrb_pq_escape(mrb, self, PQescapeIdentifier);
+}
+
+static mrb_value
+mrb_PQescapeLiteral_m(mrb_state *mrb, mrb_value self)
+{
+  return mrb_pq_escape(mrb, self, PQescapeLiteral);
+}
+
+static mrb_value
+mrb_PQcmdStatus_m(mrb_state *mrb, mrb_value self)
+{
+  PGresult *result = (PGresult *) mrb_data_check_get_ptr(mrb, self, &mrb_PGresult_type);
+  return mrb_str_new_cstr(mrb, PQcmdStatus(result));
+}
+
+static mrb_value
+mrb_PQcmdTuples_m(mrb_state *mrb, mrb_value self)
+{
+  PGresult *result = (PGresult *) mrb_data_check_get_ptr(mrb, self, &mrb_PGresult_type);
+  const char *tuples = PQcmdTuples(result);
+  if (tuples[0] == '\0') {
+    /* the command doesn't report a row count (CREATE TABLE, BEGIN, ...) */
+    return mrb_nil_value();
+  }
+  return mrb_int_value(mrb, (mrb_int) strtoll(tuples, NULL, 10));
+}
+
+static mrb_value
+mrb_PQresultErrorMessage_m(mrb_state *mrb, mrb_value self)
+{
+  const PGresult *result = (const PGresult *) mrb_data_check_get_ptr(mrb, self, &mrb_PGresult_type);
+  return mrb_str_new_cstr(mrb, PQresultErrorMessage(result));
+}
+
+/* ===================================================================
+ * end primitives for tooling
+ * =================================================================== */
+
 typedef struct {
   mrb_PQnoticeReceiver_arg *cb;
   PGresult *copy;
@@ -1180,6 +1271,9 @@ mrb_mruby_postgresql_gem_init(mrb_state *mrb)
   mrb_define_method_id(mrb, pq_class, MRB_SYM(put_copy_data), mrb_PQputCopyData_m, MRB_ARGS_REQ(1));
   mrb_define_method_id(mrb, pq_class, MRB_SYM(put_copy_end), mrb_PQputCopyEnd_m, MRB_ARGS_OPT(1));
   mrb_define_method_id(mrb, pq_class, MRB_SYM(get_copy_data), mrb_PQgetCopyData_m, MRB_ARGS_NONE());
+  mrb_define_method_id(mrb, pq_class, MRB_SYM(transaction_status), mrb_PQtransactionStatus_m, MRB_ARGS_NONE());
+  mrb_define_method_id(mrb, pq_class, MRB_SYM(escape_identifier), mrb_PQescapeIdentifier_m, MRB_ARGS_REQ(1));
+  mrb_define_method_id(mrb, pq_class, MRB_SYM(escape_literal), mrb_PQescapeLiteral_m, MRB_ARGS_REQ(1));
   /* Pq::Notify is fleshed out in mrblib/pq.rb; defined here so that
      mrb_class_get_under_id always finds it. */
   pq_notify_class = mrb_define_class_under_id(mrb, pq_class, MRB_SYM(Notify), mrb->object_class);
@@ -1209,6 +1303,9 @@ mrb_mruby_postgresql_gem_init(mrb_state *mrb)
   mrb_define_method_id(mrb, pq_result_mixins, MRB_SYM(nparams), mrb_PQnparams, MRB_ARGS_NONE());
   mrb_define_method_id(mrb, pq_result_mixins, MRB_SYM(paramtype), mrb_PQparamtype, MRB_ARGS_REQ(1));
   mrb_define_method_id(mrb, pq_result_mixins, MRB_SYM(ftype), mrb_PQftype, MRB_ARGS_REQ(1));
+  mrb_define_method_id(mrb, pq_result_mixins, MRB_SYM(cmd_status), mrb_PQcmdStatus_m, MRB_ARGS_NONE());
+  mrb_define_method_id(mrb, pq_result_mixins, MRB_SYM(cmd_tuples), mrb_PQcmdTuples_m, MRB_ARGS_NONE());
+  mrb_define_method_id(mrb, pq_result_mixins, MRB_SYM(error_message), mrb_PQresultErrorMessage_m, MRB_ARGS_NONE());
   pq_result_class = mrb_define_class_under_id(mrb, pq_class, MRB_SYM(Result), mrb->object_class);
   MRB_SET_INSTANCE_TT(pq_result_class, MRB_TT_DATA);
   mrb_include_module(mrb, pq_result_class, pq_result_mixins);

--- a/test/pq.rb
+++ b/test/pq.rb
@@ -379,3 +379,60 @@ assert("COPY: put_copy_end with message aborts, connection recovers") do
   assert_equal [[0]], conn.exec("select count(*)::int4 from copy_abort_test").to_ary
   conn.close
 end
+
+# ===========================================================================
+# Primitives for tooling (migration gems etc.)
+# ===========================================================================
+
+assert("transaction_status follows BEGIN/error/ROLLBACK") do
+  conn = Pq.new("postgresql://localhost/postgres")
+  assert_equal :idle, conn.transaction_status
+  conn.exec("BEGIN")
+  assert_equal :intrans, conn.transaction_status
+  conn.exec("this is not sql")           # error result -> aborted transaction
+  assert_equal :inerror, conn.transaction_status
+  conn.exec("ROLLBACK")
+  assert_equal :idle, conn.transaction_status
+  conn.close
+  assert_raise(IOError) { conn.transaction_status }
+end
+
+assert("escape_identifier quotes and doubles embedded quotes") do
+  conn = Pq.new("postgresql://localhost/postgres")
+  assert_equal "\"users\"", conn.escape_identifier("users")
+  assert_equal "\"weird \"\"name\"\"\"", conn.escape_identifier("weird \"name\"")
+  # usable in real SQL
+  res = conn.exec("SELECT 1::int4 AS #{conn.escape_identifier("weird \"col\"")}")
+  assert_equal "weird \"col\"", res.fname(0)
+  conn.close
+end
+
+assert("escape_literal quotes string values") do
+  conn = Pq.new("postgresql://localhost/postgres")
+  assert_equal "'it''s'", conn.escape_literal("it's")
+  res = conn.exec("SELECT #{conn.escape_literal("it's")}::text")
+  assert_equal [["it's"]], res.to_ary
+  conn.close
+end
+
+assert("cmd_status and cmd_tuples report command outcomes") do
+  conn = Pq.new("postgresql://localhost/postgres")
+  conn.exec("CREATE TEMP TABLE prim_t (id int4)")
+  res = conn.exec("INSERT INTO prim_t VALUES (1), (2)")
+  assert_equal "INSERT 0 2", res.cmd_status
+  assert_equal 2, res.cmd_tuples
+  assert_equal 2, conn.exec("UPDATE prim_t SET id = id + 1").cmd_tuples
+  assert_equal 1, conn.exec("DELETE FROM prim_t WHERE id = 2").cmd_tuples
+  res = conn.exec("CREATE TEMP TABLE prim_t2 (id int4)")
+  assert_equal "CREATE TABLE", res.cmd_status
+  assert_nil res.cmd_tuples               # no row count for DDL
+  conn.close
+end
+
+assert("Result#error_message returns the full server message") do
+  conn = Pq.new("postgresql://localhost/postgres")
+  res = conn.exec("this is not sql")
+  assert_include res.error_message, "syntax error"
+  assert_equal "", conn.exec("SELECT 1").error_message
+  conn.close
+end


### PR DESCRIPTION
Schema migrations and similar higher-level concerns deliberately stay **out** of this gem: they belong in a database-agnostic gem that drives several backends (PostgreSQL, SQLite, MySQL, ...) through per-backend adapters. This PR adds the thin libpq wrappers such an adapter needs — and nothing else:

| Method | Wraps | Adapter need |
|---|---|---|
| `conn.transaction_status` | `PQtransactionStatus` | transaction bookkeeping (`:idle`, `:active`, `:intrans`, `:inerror`, `:unknown`) without tracking state in Ruby |
| `conn.escape_identifier(str)` | `PQescapeIdentifier` | libpq's own quoting for dynamic table names |
| `conn.escape_literal(str)` | `PQescapeLiteral` | safe literals where `$1` parameters cannot go (DDL) |
| `res.cmd_status` | `PQcmdStatus` | command tag |
| `res.cmd_tuples` | `PQcmdTuples` | affected-row count (`nil` when the command reports none) |
| `res.error_message` | `PQresultErrorMessage` | full server error text — unreachable until now, since `Exception#message` cannot read data-wrapped result objects |

Everything else a migration adapter needs already exists: parameterized `exec`, plain-SQL transactions, and error results with full diagnostics.

The escape wrappers build the mruby string under `mrb_protect_error` so `PQfreemem` of libpq's malloc'd buffer is guaranteed, mirroring the COPY row path.

Includes 5 live tests (transaction-status lifecycle including the aborted state, identifier/literal escaping round-tripped through real queries, command tag / affected rows, full error message) and a README section describing the tooling story.